### PR TITLE
Add choonkeat/attache to File Uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The goal is to help every Rails developer to build an awesome Rails product/serv
 * [fog](https://github.com/fog/fog) - Fog is the Ruby cloud services library, top to bottom.
 * [refile](https://github.com/refile/refile) - Refile is a modern file upload library for Ruby applications. It is simple, yet powerful.
 * [Paperclip](https://github.com/thoughtbot/paperclip) - Easy file attachment management for ActiveRecord.
+* [attache](https://github.com/choonkeat/attache) - Standalone image and file server to decouple your app from file management concerns: https://attache-demo.herokuapp.com.
 
 ## Searching
 * [ransack](https://github.com/activerecord-hackery/ransack) - Ransack enables the creation of both simple and advanced search forms for your Ruby on Rails application.


### PR DESCRIPTION
New file upload solution: https://github.com/choonkeat/attache, production ready.

More about attache: [slides](http://www.slideshare.net/choonkeat/file-upload-2015), [blog post](http://blog.choonkeat.com/weblog/2015/10/file-uploads-2015.html).
